### PR TITLE
Allow access to the underlying GLFW.Window

### DIFF
--- a/GPipe-GLFW/GPipe-GLFW.cabal
+++ b/GPipe-GLFW/GPipe-GLFW.cabal
@@ -1,5 +1,5 @@
 name:                GPipe-GLFW
-version:             1.2
+version:             1.3
 cabal-version:       >=1.10
 build-type:          Simple
 author:              Patrick Redmond
@@ -26,6 +26,8 @@ library
   ghc-options:         -Wall
   default-language:    Haskell2010
   exposed-modules:     Graphics.GPipe.Context.GLFW
+                     , Graphics.GPipe.Context.GLFW.Input
+                     , Graphics.GPipe.Context.GLFW.Unsafe
   other-modules:
                        Graphics.GPipe.Context.GLFW.Resource
                        Graphics.GPipe.Context.GLFW.Util

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
@@ -4,6 +4,7 @@ module Graphics.GPipe.Context.GLFW
   newContext',
   BadWindowHintsException(..),
   GLFWWindow(),
+  getGLFWWindow,
   WindowConf(..), defaultWindowConf,
   getCursorPos, getMouseButton, getKey, windowShouldClose,
   MouseButtonState(..), MouseButton(..), KeyState(..), Key(..),
@@ -14,7 +15,7 @@ import qualified Graphics.GPipe.Context.GLFW.Format as Format
 import qualified Graphics.GPipe.Context.GLFW.Resource as Resource
 import Graphics.GPipe.Context.GLFW.Resource (WindowConf, defaultWindowConf)
 import qualified Graphics.GPipe.Context.GLFW.Util as Util
-import qualified Graphics.UI.GLFW as GLFW (getCursorPos, getMouseButton, getKey, windowShouldClose, makeContextCurrent, destroyWindow, pollEvents)
+import qualified Graphics.UI.GLFW as GLFW (Window, getCursorPos, getMouseButton, getKey, windowShouldClose, makeContextCurrent, destroyWindow, pollEvents)
 
 import Control.Monad.IO.Class (MonadIO)
 import Graphics.GPipe.Context (ContextFactory, ContextHandle(..),ContextT,withContextWindow)
@@ -104,6 +105,10 @@ createContext extraHints conf msgC share fmt = do
         makeContext :: Maybe Resource.Window -> IO Resource.Window
         makeContext Nothing = Resource.newContext Nothing hints (Just conf)
         makeContext (Just s) = Resource.newSharedContext s hints (Just conf)
+
+-- | Gets the underlying 'GLFW.Window' object out of the 'GLFWWindow'.
+getGLFWWindow :: GLFWWindow -> GLFW.Window
+getGLFWWindow = unGLFWWindow
 
 -- | Is the user allowed to use the given WindowHint?
 allowedHint :: WindowHint -> Bool

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
@@ -1,25 +1,24 @@
 {-# LANGUAGE RankNTypes, GADTs #-}
 module Graphics.GPipe.Context.GLFW
-( newContext,
+(
+  -- * Creating contexts
+  newContext,
   newContext',
+  -- * Data types
   BadWindowHintsException(..),
   GLFWWindow(),
-  getGLFWWindow,
-  WindowConf(..), defaultWindowConf,
-  getCursorPos, getMouseButton, getKey, windowShouldClose,
-  MouseButtonState(..), MouseButton(..), KeyState(..), Key(..),
+  WindowConf(..), defaultWindowConf
 ) where
 
 import qualified Control.Concurrent as C
 import qualified Graphics.GPipe.Context.GLFW.Format as Format
 import qualified Graphics.GPipe.Context.GLFW.Resource as Resource
-import Graphics.GPipe.Context.GLFW.Resource (WindowConf, defaultWindowConf)
+import Graphics.GPipe.Context.GLFW.Resource (WindowConf, defaultWindowConf, GLFWWindow(..))
 import qualified Graphics.GPipe.Context.GLFW.Util as Util
-import qualified Graphics.UI.GLFW as GLFW (Window, getCursorPos, getMouseButton, getKey, windowShouldClose, makeContextCurrent, destroyWindow, pollEvents)
+import qualified Graphics.UI.GLFW as GLFW (makeContextCurrent, destroyWindow, pollEvents)
 
-import Control.Monad.IO.Class (MonadIO)
-import Graphics.GPipe.Context (ContextFactory, ContextHandle(..),ContextT,withContextWindow)
-import Graphics.UI.GLFW (WindowHint(..), MouseButtonState(..), MouseButton(..), KeyState(..), Key(..))
+import Graphics.GPipe.Context (ContextFactory, ContextHandle(..))
+import Graphics.UI.GLFW (WindowHint(..))
 import Data.IORef
 import Control.Monad (when, unless)
 import Control.Exception (Exception, throwIO)
@@ -31,9 +30,6 @@ data Message where
 
 ------------------------------------------------------------------------------
 -- Top-level
-
--- | An opaque value representing a GLFW OpenGL context window.
-newtype GLFWWindow = GLFWWindow { unGLFWWindow :: Resource.Window }
 
 -- | An exception which is thrown when you try to use 'WindowHint's that need to
 -- be controlled by this library. Contains a list of the offending hints.
@@ -105,15 +101,6 @@ createContext extraHints conf msgC share fmt = do
         makeContext :: Maybe Resource.Window -> IO Resource.Window
         makeContext Nothing = Resource.newContext Nothing hints (Just conf)
         makeContext (Just s) = Resource.newSharedContext s hints (Just conf)
-
--- | Gets the underlying 'GLFW.Window' object out of the 'GLFWWindow'.
---
--- Can be used inside a 'ContextT' as follows:
---
--- > withContextWindow (\win -> doSomething (getGLFWWindow win))
---
-getGLFWWindow :: GLFWWindow -> GLFW.Window
-getGLFWWindow = unGLFWWindow
 
 -- | Is the user allowed to use the given WindowHint?
 allowedHint :: WindowHint -> Bool
@@ -197,20 +184,5 @@ contextDeleteImpl msgC = do
     syncMainWait <- C.newEmptyMVar
     C.writeChan msgC $ ReqShutDown syncMainWait
     C.takeMVar syncMainWait
-
-------------------------------------------------------------------------------
--- Exposed window actions
-
-getCursorPos :: MonadIO m => ContextT GLFWWindow os f m (Double, Double)
-getCursorPos = withContextWindow (GLFW.getCursorPos . unGLFWWindow)
-
-getMouseButton :: MonadIO m => MouseButton -> ContextT GLFWWindow os f m MouseButtonState
-getMouseButton mb = withContextWindow (\(GLFWWindow w) -> GLFW.getMouseButton w mb)
-
-getKey :: MonadIO m => Key -> ContextT GLFWWindow os f m KeyState
-getKey k = withContextWindow (\(GLFWWindow w) -> GLFW.getKey w k)
-
-windowShouldClose :: MonadIO m => ContextT GLFWWindow os f m Bool
-windowShouldClose = withContextWindow (GLFW.windowShouldClose . unGLFWWindow)
 
 -- eof

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
@@ -107,6 +107,11 @@ createContext extraHints conf msgC share fmt = do
         makeContext (Just s) = Resource.newSharedContext s hints (Just conf)
 
 -- | Gets the underlying 'GLFW.Window' object out of the 'GLFWWindow'.
+--
+-- Can be used inside a 'ContextT' as follows:
+--
+-- > withContextWindow (\win -> doSomething (getGLFWWindow win))
+--
 getGLFWWindow :: GLFWWindow -> GLFW.Window
 getGLFWWindow = unGLFWWindow
 

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
@@ -7,16 +7,19 @@ module Graphics.GPipe.Context.GLFW
   -- * Data types
   BadWindowHintsException(..),
   GLFWWindow(),
-  WindowConf(..), defaultWindowConf
+  WindowConf(..), defaultWindowConf,
+  -- * Re-exported window actions
+  module Input
 ) where
 
-import qualified Control.Concurrent as C
 import qualified Graphics.GPipe.Context.GLFW.Format as Format
+import Graphics.GPipe.Context.GLFW.Input as Input
 import qualified Graphics.GPipe.Context.GLFW.Resource as Resource
 import Graphics.GPipe.Context.GLFW.Resource (WindowConf, defaultWindowConf, GLFWWindow(..))
 import qualified Graphics.GPipe.Context.GLFW.Util as Util
-import qualified Graphics.UI.GLFW as GLFW (makeContextCurrent, destroyWindow, pollEvents)
 
+import qualified Control.Concurrent as C
+import qualified Graphics.UI.GLFW as GLFW (makeContextCurrent, destroyWindow, pollEvents)
 import Graphics.GPipe.Context (ContextFactory, ContextHandle(..))
 import Graphics.UI.GLFW (WindowHint(..))
 import Data.IORef

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Input.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Input.hs
@@ -1,0 +1,37 @@
+-- | Window actions, mostly corresponding to user input. Analogous to those from
+-- 'Graphics.UI.GLFW', but in the GPipe 'ContextT' monad.
+module Graphics.GPipe.Context.GLFW.Input
+(
+  -- * Exposed actions
+  getCursorPos,
+  getMouseButton,
+  getKey,
+  windowShouldClose,
+  -- * Re-exported from GLFW
+  MouseButtonState(..), MouseButton(..), KeyState(..), Key(..)
+) where
+
+import Graphics.GPipe.Context.GLFW.Unsafe (GLFWWindow(..))
+
+import Control.Monad.IO.Class (MonadIO)
+import Graphics.GPipe.Context (ContextT, withContextWindow)
+import qualified Graphics.UI.GLFW as GLFW (getCursorPos, getMouseButton, getKey, windowShouldClose)
+import Graphics.UI.GLFW (MouseButtonState(..), MouseButton(..), KeyState(..), Key(..))
+
+-- | Gets the current cursor position, in pixels relative to the top-left corner
+-- of the window.
+getCursorPos :: MonadIO m => ContextT GLFWWindow os f m (Double, Double)
+getCursorPos = withContextWindow (GLFW.getCursorPos . getGLFWWindow)
+
+-- | Gets the state of the specified 'MouseButton'.
+getMouseButton :: MonadIO m => MouseButton -> ContextT GLFWWindow os f m MouseButtonState
+getMouseButton mb = withContextWindow (\(GLFWWindow w) -> GLFW.getMouseButton w mb)
+
+-- | Gets the state of the specified 'Key'.
+getKey :: MonadIO m => Key -> ContextT GLFWWindow os f m KeyState
+getKey k = withContextWindow (\(GLFWWindow w) -> GLFW.getKey w k)
+
+-- | Returns 'True' if the window should close (e.g. because the user pressed
+-- the \'x\' button).
+windowShouldClose :: MonadIO m => ContextT GLFWWindow os f m Bool
+windowShouldClose = withContextWindow (GLFW.windowShouldClose . getGLFWWindow)

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Resource.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Resource.hs
@@ -26,15 +26,6 @@ import Control.Applicative ((<$>))
 -- | A value representing a GLFW OpenGL context window.
 newtype GLFWWindow = GLFWWindow
   {
-    -- | Gets the underlying 'GLFW.Window' object out of the 'GLFWWindow'.
-    --
-    -- Can be used inside a 'Graphics.GPipe.Context.ContextT' as follows:
-    --
-    -- > withContextWindow (\win -> doSomething (getGLFWWindow win))
-    --
-    -- WARNING: It is possible to do bad things with this. For example, using
-    -- 'GLFW.makeContextCurrent' could cause GPipe to lose control of the window,
-    -- and 'GLFW.destroyWindow' is bad for obvious reasons.
     getGLFWWindow :: GLFW.Window
   }
 

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Resource.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Resource.hs
@@ -15,7 +15,7 @@ import qualified Control.Exception as Exc
 import qualified Data.Maybe as M
 import qualified Text.Printf as P
 
-#if __GLASGOW_HASKELL__ <= 708
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative ((<$>))
 #endif
 

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Resource.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Resource.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE CPP #-}
--- Bracketed GLFW resource initializers
+-- | Bracketed GLFW resource initializers.
 module Graphics.GPipe.Context.GLFW.Resource
 ( newContext
 , newSharedContext
 , WindowConf(..)
+, GLFWWindow(..)
 , defaultWindowConf
 , Window
 , ErrorCallback
@@ -22,6 +23,21 @@ import Control.Applicative ((<$>))
 ------------------------------------------------------------------------------
 -- Types & Constants
 
+-- | A value representing a GLFW OpenGL context window.
+newtype GLFWWindow = GLFWWindow
+  {
+    -- | Gets the underlying 'GLFW.Window' object out of the 'GLFWWindow'.
+    --
+    -- Can be used inside a 'Graphics.GPipe.Context.ContextT' as follows:
+    --
+    -- > withContextWindow (\win -> doSomething (getGLFWWindow win))
+    --
+    -- WARNING: It is possible to do bad things with this. For example, using
+    -- 'GLFW.makeContextCurrent' could cause GPipe to lose control of the window,
+    -- and 'GLFW.destroyWindow' is bad for obvious reasons.
+    getGLFWWindow :: GLFW.Window
+  }
+
 -- reexports
 type Window = GLFW.Window
 type ErrorCallback = GLFW.ErrorCallback
@@ -30,13 +46,17 @@ type ErrorCallback = GLFW.ErrorCallback
 defaultOnError :: ErrorCallback
 defaultOnError err msg = fail $ P.printf "%s: %s" (show err) msg
 
--- initial window size & title suggestions
+-- | Initial window size and title suggestions for GLFW. The window will usually
+-- be set to the given size with the given title, unless the window manager
+-- overrides this.
 data WindowConf = WindowConf
     { width :: Int
     , height :: Int
     , title :: String
     }
 
+-- | A set of sensible defaults for the 'WindowConf'. Used by
+-- 'Graphics.GPipe.Context.GLFW.newContext'.
 defaultWindowConf :: WindowConf
 defaultWindowConf = WindowConf 1024 768 "GLFW Window"
 

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Resource.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Resource.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE CPP #-}
 -- Bracketed GLFW resource initializers
 module Graphics.GPipe.Context.GLFW.Resource
 ( newContext
@@ -14,7 +15,9 @@ import qualified Control.Exception as Exc
 import qualified Data.Maybe as M
 import qualified Text.Printf as P
 
+#if __GLASGOW_HASKELL__ <= 708
 import Control.Applicative ((<$>))
+#endif
 
 ------------------------------------------------------------------------------
 -- Types & Constants

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Unsafe.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Unsafe.hs
@@ -1,0 +1,20 @@
+-- | Exposes some underlying implementation details which can be used to
+-- gain access to 'Graphics.UI.GLFW' functionality that isn't exposed by this
+-- library otherwise, but which can be dangerous if used incorrectly.
+--
+-- The underlying 'Graphics.UI.GLFW.Window' object can be retrieved from a
+-- 'GLFWWindow' using 'getGLFWWindow'.It can be used inside a
+-- 'Graphics.GPipe.Context.ContextT' as follows:
+--
+-- > withContextWindow (\win -> doSomething (getGLFWWindow win))
+--
+-- Bear in mind that it is possible to do bad things with this. For example, using
+-- 'GLFW.makeContextCurrent' could cause GPipe to lose control of the window,
+-- and 'GLFW.destroyWindow' is bad for obvious reasons.
+--
+-- See 'Graphics.GPipe.Context.GLFW.Input' for concrete examples.
+module Graphics.GPipe.Context.GLFW.Unsafe
+       ( GLFWWindow(..) )
+       where
+
+import Graphics.GPipe.Context.GLFW.Resource (GLFWWindow(..))


### PR DESCRIPTION
There are a lot of things that GLFW lets you do which require access to the `Window` object that it provides you, so it is quite limiting not to have access to it. I suppose ideally everything useful should have a counterpart `ContextT GLFWWindow os f m` monadic action, but that would be a lot of work to implement where this allows maximum flexibility. Let me know if you see any problems with this method.

Specifically, what I want to be able to do is register callbacks for keyboard and mouse events, which I am then hijacking into a `pipes` `Producer` like this:

```haskell
glfwCharEvents :: MonadIO m => IO (Producer Char IO (), ContextT GLFWWindow os f m ())
glfwCharEvents = do
  (output, input) <- spawn unbounded
  let callback _ char = void . atomically $ send output char
      register =
        withContextWindow
        (\win -> liftIO $ setCharCallback (getGLFWWindow win) (Just callback))

  return (fromInput input, register)
```

I like this pattern because it allows me to run my rendering and logic loops in different threads, and escape from the `ContextT` monad altogether in my non-rendering code (so long as I call the `register` function at `GPipe` initialisation in my rendering code).

EDIT: Turns out I have to use

```haskell
unsafeCoerceContextOS :: ContextT GLFWWindow os1 f m a -> ContextT GLFWWindow os f m a
unsafeCoerceContextOS = unsafeCoerce
```

in order to get Haskell to actually allow me to use my `register` function since any use of `glfwCharEvents` outside a `ContextT` monad must bind the `os` type to something, so it is then rejected once `runContextT` needs its `forall os`. This is pretty annoying (why can't Haskell just have dependent types?!), but not enough to stop me using this pattern since it's so nice otherwise!