### PR TITLE
Ready for the next GPipe-GLFW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 cabal.sandbox.config
 dist/
+dist-*
+.ghc.environment.*
 .stack-work/
 .cabal-sandbox/
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ before_install:
   - cabal install alex
   - cabal install happy
   - cabal install c2hs
+script:
+  - cabal v2-build all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: haskell
+addons:
+  apt:
+    packages:
+      - libglfw3-dev
+ghc:
+  - "8.4"
+  - "8.6"
+before_install:
+  - cabal install alex
+  - cabal install happy
+  - cabal install c2hs

--- a/GPipe-GLFW/GPipe-GLFW.cabal
+++ b/GPipe-GLFW/GPipe-GLFW.cabal
@@ -21,7 +21,7 @@ data-files:     CHANGELOG.md
 library
   hs-source-dirs:      src
   build-depends:       base                   >= 4.7 && <5
-                     , stm                    >= 2.4 && <2.6
+                     , stm                    >= 2.4 && <3
                      , containers             >= 0.5 && <0.7
                      , async                  >= 2.1 && <2.3
                      , GLFW-b                 >= 3.2 && <3.3

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: ./GPipe-GLFW
+packages: ./Smoketests


### PR DESCRIPTION
I have bumped the upper limits for stm, so packages that depend on GPipe-GLFW can pull it without conflicts. Also added some support for cabal v2. I can also add .travis.yml for testing if you want. Just let me know what versions of ghc you would like to test.