### PR TITLE
Relax GLFW-b upper bound to allow 3.3

### DIFF
--- a/GPipe-GLFW/GPipe-GLFW.cabal
+++ b/GPipe-GLFW/GPipe-GLFW.cabal
@@ -24,7 +24,7 @@ library
                      , stm                    >= 2.4 && <3
                      , containers             >= 0.5 && <0.7
                      , async                  >= 2.1 && <2.3
-                     , GLFW-b                 >= 3.2 && <3.3
+                     , GLFW-b                 >= 3.2 && <3.4
                      , GPipe                  >= 2.2 && <2.5
   ghc-options:         -Wall -Wno-orphans
   default-language:    Haskell2010


### PR DESCRIPTION
No issues found during testing.