### PR TITLE
Add a way to override the OpenGL version required by GPipe.

### DIFF
--- a/GPipe-GLFW/GPipe-GLFW.cabal
+++ b/GPipe-GLFW/GPipe-GLFW.cabal
@@ -1,5 +1,5 @@
 name:           GPipe-GLFW
-version:        1.5.0.0
+version:        1.4.2.0
 cabal-version:  >=1.10
 build-type:     Simple
 author:         Patrick Redmond
@@ -49,4 +49,4 @@ source-repository this
   type:     git
   location: https://github.com/plredmond/GPipe-GLFW.git
   subdir:   GPipe-GLFW
-  tag:      v1.5.0.0
+  tag:      v1.4.2.0

--- a/GPipe-GLFW/GPipe-GLFW.cabal
+++ b/GPipe-GLFW/GPipe-GLFW.cabal
@@ -1,5 +1,5 @@
 name:           GPipe-GLFW
-version:        1.4.1.4
+version:        1.5.0.0
 cabal-version:  >=1.10
 build-type:     Simple
 author:         Patrick Redmond
@@ -49,4 +49,4 @@ source-repository this
   type:     git
   location: https://github.com/plredmond/GPipe-GLFW.git
   subdir:   GPipe-GLFW
-  tag:      v1.4.1.4
+  tag:      v1.5.0.0

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
@@ -4,15 +4,15 @@
 -- Interactive applications will need "Graphics.GPipe.Context.GLFW.Input".
 module Graphics.GPipe.Context.GLFW (
 -- * GPipe context handler for GLFW
+OpenGlVersion(..),
 Handle(),
 GLFWWindow(),
 -- ** Configuration
 -- *** Default configs
 defaultHandleConfig,
-defaultHandleConfigWithVersion,
 defaultWindowConfig,
 -- *** Custom configs
-ContextHandlerParameters(HandleConfig, configErrorCallback, configEventPolicy),
+ContextHandlerParameters(HandleConfig, configErrorCallback, configEventPolicy, configOpenGlVersion),
 -- | Configuration for the GLFW handle.
 --
 -- [@'HandleConfig'@] Constructor

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
@@ -9,6 +9,7 @@ GLFWWindow(),
 -- ** Configuration
 -- *** Default configs
 defaultHandleConfig,
+defaultHandleConfigWithVersion,
 defaultWindowConfig,
 -- *** Custom configs
 ContextHandlerParameters(HandleConfig, configErrorCallback, configEventPolicy),

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Format.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Format.hs
@@ -30,22 +30,22 @@ allowedHint (WindowHint'OpenGLForwardCompat _) = False
 allowedHint (WindowHint'OpenGLProfile _) = False
 allowedHint _ = True
 
-unconditionalHints :: [GLFW.WindowHint]
-unconditionalHints =
-    [ GLFW.WindowHint'ContextVersionMajor 3
-    , GLFW.WindowHint'ContextVersionMinor 3
-    , GLFW.WindowHint'OpenGLForwardCompat True
-    , GLFW.WindowHint'OpenGLProfile GLFW.OpenGLProfile'Core
+versionToHints :: (Int, Int) -> [GLFW.WindowHint]
+versionToHints (major, minor) =
+    [ WindowHint'ContextVersionMajor major
+    , WindowHint'ContextVersionMinor minor
+    , WindowHint'OpenGLForwardCompat True
+    , WindowHint'OpenGLProfile GLFW.OpenGLProfile'Core
     ]
 
 bitsToHints :: Maybe GPipe.WindowBits -> [GLFW.WindowHint]
 bitsToHints Nothing = [GLFW.WindowHint'Visible False]
 bitsToHints (Just ((red, green, blue, alpha, sRGB), depth, stencil)) =
-    [ GLFW.WindowHint'sRGBCapable sRGB
-    , GLFW.WindowHint'RedBits $ Just red
-    , GLFW.WindowHint'GreenBits $ Just green
-    , GLFW.WindowHint'BlueBits $ Just blue
-    , GLFW.WindowHint'AlphaBits $ Just alpha
-    , GLFW.WindowHint'DepthBits $ Just depth
-    , GLFW.WindowHint'StencilBits $ Just stencil
+    [ WindowHint'sRGBCapable sRGB
+    , WindowHint'RedBits $ Just red
+    , WindowHint'GreenBits $ Just green
+    , WindowHint'BlueBits $ Just blue
+    , WindowHint'AlphaBits $ Just alpha
+    , WindowHint'DepthBits $ Just depth
+    , WindowHint'StencilBits $ Just stencil
     ]

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Format.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Format.hs
@@ -15,6 +15,11 @@ data UnsafeWindowHintsException
     deriving Show
 instance Exception UnsafeWindowHintsException
 
+data OpenGlVersion = OpenGlVersion
+    { openGlVersionMajor :: Int
+    , openGlVersionMinor :: Int
+    }
+
 allowedHint :: WindowHint -> Bool
 allowedHint (WindowHint'Visible _) = False
 allowedHint (WindowHint'sRGBCapable _) = False

--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Format.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW/Format.hs
@@ -30,8 +30,8 @@ allowedHint (WindowHint'OpenGLForwardCompat _) = False
 allowedHint (WindowHint'OpenGLProfile _) = False
 allowedHint _ = True
 
-versionToHints :: (Int, Int) -> [GLFW.WindowHint]
-versionToHints (major, minor) =
+versionToHints :: Int -> Int -> [GLFW.WindowHint]
+versionToHints major minor =
     [ WindowHint'ContextVersionMajor major
     , WindowHint'ContextVersionMinor minor
     , WindowHint'OpenGLForwardCompat True


### PR DESCRIPTION
What do you think of this? I’ve not broken the API and tried not to release too many constraints on how the contexts are created.