### PR TITLE
Fix #7 Expose `HandleConfig` `configLogger`.

### DIFF
--- a/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
+++ b/GPipe-GLFW/src/Graphics/GPipe/Context/GLFW.hs
@@ -12,7 +12,7 @@ GLFWWindow(),
 defaultHandleConfig,
 defaultWindowConfig,
 -- *** Custom configs
-ContextHandlerParameters(HandleConfig, configErrorCallback, configEventPolicy, configOpenGlVersion),
+ContextHandlerParameters(..),
 -- | Configuration for the GLFW handle.
 --
 -- [@'HandleConfig'@] Constructor


### PR DESCRIPTION
Allow configuration of the `Logger`.